### PR TITLE
added xtal sdk (gitignore only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ sysinfo.txt
 
 # Crashlytics generated file
 crashlytics-build.properties
+
+# Exclude XTAL SDK
+Assets/vrgineers/
+Assets/vrgineers.meta


### PR DESCRIPTION
Only gitignore has been added, as the SDK itself shall not be put into the public repository.